### PR TITLE
Add commands to instate an opt-in to the AW Discord WtC channel to ease the spoiler policy and reduce the risk of EB leaks.

### DIFF
--- a/index.js
+++ b/index.js
@@ -430,16 +430,20 @@ client.on("message", async message => {
   }
   
   if(command === "pre-lockdown") {
-    if(!message.member) return;
-	if(message.member.roles.cache.some(role => role.name === 'moderator') || message.member.roles.cache.some(role => role.name === '@admin')) {
+    if(!message.member) {
+	  message.channel.send("Server use only.");
+	}
+	else if(message.member.roles.cache.some(role => role.name === 'moderator') || message.member.roles.cache.some(role => role.name === '@admin')) {
       storage.setItemSync('lockdown', 1);
 	  
 	  message.channel.send("#worththecandle is now in pre-lockdown, new users must type +unlock-wtc in #bot-ez to access the channel.");
 	}
   }
   if(command === "lockdown") {
-    if(!message.member) return;
-	if(message.member.roles.cache.some(role => role.name === 'moderator') || message.member.roles.cache.some(role => role.name === '@admin')) {
+    if(!message.member) {
+	  message.channel.send("Server use only.");
+	}
+	else if(message.member.roles.cache.some(role => role.name === 'moderator') || message.member.roles.cache.some(role => role.name === '@admin')) {
       storage.setItemSync('lockdown', 2);
 	  
 	  const role = message.guild.roles.cache.find(role => role.name === 'wtc-lockout');

--- a/index.js
+++ b/index.js
@@ -60,12 +60,12 @@ let downloadTask = new cron.CronJob('13 00 00 * * *', downloadHTML);
 
 
 var grep = function(what, where, callback){
-	var exec = require('child_process').exec;
-	exec('\grep "' + what.replace(/"/g,"\\\"") + '" ' + where + ' -hiw -m 5', function(err, stdin, stdout){ 
-		var list = {}
-		var results = stdin.split('\n').slice(0,10);
-	    callback(results)
-	});
+    var exec = require('child_process').exec;
+    exec('\grep "' + what.replace(/"/g,"\\\"") + '" ' + where + ' -hiw -m 5', function(err, stdin, stdout){ 
+        var list = {}
+        var results = stdin.split('\n').slice(0,10);
+        callback(results)
+    });
 }
 
 function authorize(credentials, callback) {
@@ -431,37 +431,37 @@ client.on("message", async message => {
   
   if(command === "pre-lockdown") {
     if(!message.member) {
-	  message.channel.send("Server use only.");
-	}
-	else if(message.member.roles.cache.some(role => role.name === 'moderator') || message.member.roles.cache.some(role => role.name === '@admin')) {
+      message.channel.send("Server use only.");
+    }
+    else if(message.member.roles.cache.some(role => role.name === 'moderator') || message.member.roles.cache.some(role => role.name === '@admin')) {
       storage.setItemSync('lockdown', 1);
-	  
-	  message.channel.send("#worththecandle is now in pre-lockdown, new users must type +unlock-wtc in #bot-ez to access the channel.");
-	}
+      
+      message.channel.send("#worththecandle is now in pre-lockdown, new users must type +unlock-wtc in #bot-ez to access the channel.");
+    }
   }
   if(command === "lockdown") {
     if(!message.member) {
-	  message.channel.send("Server use only.");
-	}
-	else if(message.member.roles.cache.some(role => role.name === 'moderator') || message.member.roles.cache.some(role => role.name === '@admin')) {
+      message.channel.send("Server use only.");
+    }
+    else if(message.member.roles.cache.some(role => role.name === 'moderator') || message.member.roles.cache.some(role => role.name === '@admin')) {
       storage.setItemSync('lockdown', 2);
-	  
-	  const role = message.guild.roles.cache.find(role => role.name === 'wtc-lockout');
-	  message.guild.members.filter(m => !m.user.bot).forEach(member => member.addRole(role));
-	  
-	  message.channel.send("#worththecandle is now in lockdown, all users (other than earlybirds) must type +unlock-wtc in #bot-ez to access the channel.");
-	}
+      
+      const role = message.guild.roles.cache.find(role => role.name === 'wtc-lockout');
+      message.guild.members.filter(m => !m.user.bot).forEach(member => member.addRole(role));
+      
+      message.channel.send("#worththecandle is now in lockdown, all users (other than earlybirds) must type +unlock-wtc in #bot-ez to access the channel.");
+    }
   }
   if(command === "lift-lockdown") {
     if(!message.member) return;
-	if(message.member.roles.cache.some(role => role.name === 'moderator') || message.member.roles.cache.some(role => role.name === '@admin')) {
+    if(message.member.roles.cache.some(role => role.name === 'moderator') || message.member.roles.cache.some(role => role.name === '@admin')) {
       storage.setItemSync('lockdown', 0);
-	  
-	  const role = message.guild.roles.cache.find(role => role.name === 'wtc-lockout');
-	  message.guild.members.filter(role => role.name === 'wtc-lockout').forEach(member => member.addRole(role));
-	  
-	  message.channel.send("#worththecandle lockdown lifted.");
-	}
+      
+      const role = message.guild.roles.cache.find(role => role.name === 'wtc-lockout');
+      message.guild.members.filter(role => role.name === 'wtc-lockout').forEach(member => member.addRole(role));
+      
+      message.channel.send("#worththecandle lockdown lifted.");
+    }
   }
     
   if(command === "testsearch") {

--- a/index.js
+++ b/index.js
@@ -145,6 +145,13 @@ client.on("guildDelete", guild => {
 });
 
 
+client.on('guildMemberAdd', member => {
+  if (storage.getItemSync("lockdown") != 0) {
+    const role = member.guild.roles.cache.find(role => role.name === 'wtc-lockout');
+    member.roles.add(role);
+  }
+});
+
 client.on("message", async message => {
   if(BANNED_CHANNEL_IDS.includes(message.channel.id)) return;
   if(message.author.bot) return;
@@ -422,6 +429,14 @@ client.on("message", async message => {
    }
   }
   
+  if(command === "pre-lockdown") {
+    if(!message.member) return;
+	if(message.member.roles.cache.some(role => role.name === 'moderator') || message.member.roles.cache.some(role => role.name === '@admin')) {
+      storage.setItemSync('lockdown', 1);
+	  
+	  message.channel.send("#worththecandle is now in pre-lockdown, new users must type +unlock-wtc in #bot-ez to access the channel.");
+	}
+  }
   if(command === "lockdown") {
     if(!message.member) return;
 	if(message.member.roles.cache.some(role => role.name === 'moderator') || message.member.roles.cache.some(role => role.name === '@admin')) {
@@ -430,7 +445,7 @@ client.on("message", async message => {
 	  const role = message.guild.roles.cache.find(role => role.name === 'wtc-lockout');
 	  message.guild.members.filter(m => !m.user.bot).forEach(member => member.addRole(role));
 	  
-	  message.channel.send("#worththecandle is now in lockdown, users (other than earlybirds) must type +unlock-wtc in #bot-ez to access the channel.");
+	  message.channel.send("#worththecandle is now in lockdown, all users (other than earlybirds) must type +unlock-wtc in #bot-ez to access the channel.");
 	}
   }
   if(command === "lift-lockdown") {

--- a/index.js
+++ b/index.js
@@ -403,6 +403,24 @@ client.on("message", async message => {
         message.channel.send("You need more Degrees of Reasonableness in order to use this command in a Direct Message.");
       }
   }
+  
+  if(command === "unlock-wtc") {
+   if(message.member){
+    if (!message.member.roles.cache.some(role => role.name === 'wtc-lockout')) {
+      console.log(message.member.user.tag + "(" + message.member.user + ") used command +unlock-wtc without the role");
+      message.channel.send("You already have access to #worththecandle.");
+    }
+    else{
+      const role = message.guild.roles.cache.find(role => role.name === 'wtc-lockout');
+      console.log(message.member.user.tag + "(" + message.member.user + ") used command +unlock-wtc with the role");
+      message.member.roles.remove(role);
+      message.channel.send("You may now read and post in #worththecandle.");
+    }
+   }
+   else{
+    message.channel.send("Please visit the Alexander Wales Discord server to use this command.");
+   }
+  }
     
   if(command === "testsearch") {
       const searchContent = args.join(" ");

--- a/index.js
+++ b/index.js
@@ -421,6 +421,29 @@ client.on("message", async message => {
     message.channel.send("Please visit the Alexander Wales Discord server to use this command.");
    }
   }
+  
+  if(command === "lockdown") {
+    if(!message.member) return;
+	if(message.member.roles.cache.some(role => role.name === 'moderator') || message.member.roles.cache.some(role => role.name === '@admin')) {
+      storage.setItemSync('lockdown', 2);
+	  
+	  const role = message.guild.roles.cache.find(role => role.name === 'wtc-lockout');
+	  message.guild.members.filter(m => !m.user.bot).forEach(member => member.addRole(role));
+	  
+	  message.channel.send("#worththecandle is now in lockdown, users (other than earlybirds) must type +unlock-wtc in #bot-ez to access the channel.");
+	}
+  }
+  if(command === "lift-lockdown") {
+    if(!message.member) return;
+	if(message.member.roles.cache.some(role => role.name === 'moderator') || message.member.roles.cache.some(role => role.name === '@admin')) {
+      storage.setItemSync('lockdown', 0);
+	  
+	  const role = message.guild.roles.cache.find(role => role.name === 'wtc-lockout');
+	  message.guild.members.filter(role => role.name === 'wtc-lockout').forEach(member => member.addRole(role));
+	  
+	  message.channel.send("#worththecandle lockdown lifted.");
+	}
+  }
     
   if(command === "testsearch") {
       const searchContent = args.join(" ");


### PR DESCRIPTION
Completed as quickly as possible so it may be used for the upcoming batch. Not very pretty, but should do its job together with a (human-created) announcement telling people to use it. See the server for extended discussion.

As implemented, there would be three admin/mod-only commands, +pre-lockdown, +lockdown and +lift-lockdown. In pre-lockdown, newly-joined users must use +unlock-wtc to read #worththecandle, this protects against accidental EB leaks as we've had in the past. Once lockdown is activated, all users are ejected from #worththecandle and must use +unlock-wtc to rejoin. This protects them from spoilers. This would be explained in a separate announcement set up around the batch release.

Completely untested, even with regards to basic syntactic errors.